### PR TITLE
feat(sprints): allow multiple sprints per project, set status to plan…

### DIFF
--- a/worksense-backend/src/controllers/sprint.controller.ts
+++ b/worksense-backend/src/controllers/sprint.controller.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from "express";
+import { db } from "../models/firebase.js";
+import { Timestamp } from "firebase-admin/firestore";
+
+// POST /projects/:projectId/sprints
+export const createSprint = async (req: Request, res: Response) => {
+  try {
+    // 1. Obtener projectId de los parámetros
+    const { projectId } = req.params;
+    if (!projectId) {
+      res.status(400).json({ error: "Falta el projectId en la ruta" });
+      return;
+    }
+
+    // 2. Validar datos de entrada
+    const { name, goal, startDate, endDate } = req.body;
+    if (!startDate || !endDate) {
+      res.status(400).json({ error: "startDate y endDate son requeridos" });
+      return;
+    }
+    const newStart = new Date(startDate);
+    const newEnd = new Date(endDate);
+    if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime())) {
+      res.status(400).json({ error: "Fechas inválidas" });
+      return;
+    }
+    if (newStart >= newEnd) {
+      res.status(400).json({ error: "startDate debe ser menor a endDate" });
+      return;
+    }
+
+    // 3. Verificar si ya hay un sprint activo
+    const sprintsRef = db.collection("projectss").doc(projectId).collection("sprints");
+    const activeSprintSnap = await sprintsRef.where("status", "==", "active").limit(1).get();
+    let newSprintStatus = "active";
+    if (!activeSprintSnap.empty) {
+      newSprintStatus = "planned"; // o "inactive" si prefieres
+    }
+
+    // 4. Verificar que no haya solapamiento de fechas
+    const overlapSnap = await sprintsRef
+      .where("startDate", "<=", newEnd)
+      .where("endDate", ">=", newStart)
+      .limit(1)
+      .get();
+    if (!overlapSnap.empty) {
+      res.status(400).json({ error: "Ya existe un sprint en esas fechas" });
+      return;
+    }
+
+    // 5. Crear el documento del sprint
+    const now = Timestamp.now();
+    const sprintData = {
+      projectId,
+      name: name || null,
+      goal: goal || null,
+      startDate: Timestamp.fromDate(newStart),
+      endDate: Timestamp.fromDate(newEnd),
+      status: newSprintStatus,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const sprintRef = await sprintsRef.add(sprintData);
+
+    // 6. Devolver el sprint creado
+    const sprintSnap = await sprintRef.get();
+    res.status(201).json({ id: sprintRef.id, ...sprintSnap.data() });
+  } catch (error) {
+    console.error("Error al crear el sprint:", error);
+    res.status(500).json({ error: "Error interno al crear el sprint" });
+  }
+}; 

--- a/worksense-backend/src/index.ts
+++ b/worksense-backend/src/index.ts
@@ -15,6 +15,7 @@ import itemsRoutes from "./routes/items.routes.js";
 import aiRoutes from "./routes/ai.routes.js";
 import adminRoutes from "./routes/admin.routes.js";
 import project_Routes from "./routes/projectRoutes.js";
+import sprintsRouter from "./routes/sprints.routes.js";
 // Documenattion Imports
 import { swaggerOptions } from "../swagger/swaggerSetup.js"; // Swagger options
 
@@ -39,6 +40,7 @@ app.use(itemsRoutes);
 app.use(aiRoutes);
 app.use(`${API_PREFIX}/admin`, adminRoutes);
 app.use(`${API_PREFIX}`, project_Routes);
+app.use(API_PREFIX, sprintsRouter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 app.get("/", (req: any, res: any) => {
   res.send("API is running...");

--- a/worksense-backend/src/routes/sprints.routes.ts
+++ b/worksense-backend/src/routes/sprints.routes.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { createSprint } from "../controllers/sprint.controller.js";
+import { verifyToken } from "../middlewares/tokenAuth.js";
+import { checkProjectMembership, checkProjectPermission } from "../middlewares/projectAuth.js";
+
+const router = Router();
+
+/**
+ * @swagger
+ * /projects/{projectId}/sprints:
+ *   post:
+ *     summary: Crear un nuevo sprint en un proyecto
+ *     tags: [Sprints]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: projectId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [startDate, endDate]
+ *             properties:
+ *               name:
+ *                 type: string
+ *               goal:
+ *                 type: string
+ *               startDate:
+ *                 type: string
+ *                 format: date-time
+ *               endDate:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       201:
+ *         description: Sprint creado correctamente
+ *       400:
+ *         description: Error de validación o solapamiento
+ *       403:
+ *         description: Permisos insuficientes
+ */
+router.post(
+  "/projects/:projectId/sprints",
+  verifyToken,
+  checkProjectMembership,
+  checkProjectPermission("manage:sprints"),
+  createSprint
+);
+
+export default router; 


### PR DESCRIPTION
###HU11: Crear y activar un nuevo Sprint — Cierre de Issue
## ¿Qué se implementó?
Se creó un endpoint REST para crear sprints en la ruta:
`POST /api/v1/projects/:projectId/sprints`

* El endpoint permite crear múltiples sprints por proyecto, pero:
* Solo un sprint puede estar activo a la vez.
* Si ya existe un sprint activo, los nuevos se crean con status "planned".
* Se valida que las fechas de los sprints no se solapen.
* Se valida que el usuario tenga el permiso manage:sprints y sea miembro del proyecto.
* Se agregaron todas las validaciones de negocio y de datos requeridas.
## Evidencia de pruebas (Postman)
# 1. Creacion de sprint nuevo (status: "Active")
* Se creó exitosamente un sprint nuevo
* Se guardaron todos sus datos correctamente
* Su estatus es "Active"
# 2. Crear un segundo sprint (status "planned")
!Sprint planned

* Se creó exitosamente un segundo sprint en el mismo proyecto.
* El status del nuevo sprint es "planned" porque ya existe uno activo.
* El endpoint responde con 201 Created y los datos del sprint.
# 3. Intento de crear sprint con fechas inválidas
!Error fechas
* El sistema respondió correctamente con un error 400 y el mensaje:
"error": "startDate debe ser menor a endDate"

## Validaciones implementadas
* Permite múltiples sprints por proyecto.
* Solo uno puede estar activo.
* No permite solapamiento de fechas.
* Valida fechas y permisos.
* Responde con mensajes claros de error.
<img width="1278" alt="Screenshot 2025-04-28 at 2 16 41 p m" src="https://github.com/user-attachments/assets/314a09f8-a767-4a21-85ca-d6a772362cb9" />
<img width="1279" alt="Screenshot 2025-04-28 at 2 01 44 p m" src="https://github.com/user-attachments/assets/36109391-5cb1-4d01-a908-d18577ef71a5" />
<img width="1279" alt="Screenshot 2025-04-28 at 1 57 38 p m" src="https://github.com/user-attachments/assets/cb456293-e528-427f-ba0c-171cdd2d5516" />




